### PR TITLE
Speed up the Sega Genesis CCA by vectorizing the CCA algorithm

### DIFF
--- a/genesis/cca.s
+++ b/genesis/cca.s
@@ -1,11 +1,15 @@
 	seg	data
 	org	$ff0000
 
-; automaton size
+; automaton size in cells
 CCA_width  equ 128
 CCA_height equ 128
 
-CCA_buf_size equ CCA_width * CCA_height
+; size of a row in bytes and in longwords
+CCA_row_bytes equ CCA_width / 2
+CCA_row_longs equ CCA_row_bytes / 4
+
+CCA_buf_size equ CCA_row_bytes * CCA_height
 CCA_buf_0:
 	ds	CCA_buf_size
 CCA_buf_1:

--- a/genesis/cca.s
+++ b/genesis/cca.s
@@ -1,14 +1,34 @@
 	seg	data
 	org	$ff0000
+
+; automaton size
+CCA_width  equ 128
+CCA_height equ 128
+
+CCA_buf_size equ CCA_width * CCA_height
 CCA_buf_0:
-	ds	$4000
+	ds	CCA_buf_size
 CCA_buf_1:
-	ds	$4000
+	ds	CCA_buf_size
+CCA_buf_xor equ CCA_buf_0 ^ CCA_buf_1
+
+CCA_vram_size equ CCA_width * CCA_height / 2
 CCA_vram_mirror:
-	ds	$4000
+	ds	CCA_vram_size
+CCA_vram_mirror1:
+	ds	CCA_vram_size
+
+DMA_vram_sizelo  equ $9300 | ((CCA_vram_size >> 1) & $ff)
+DMA_vram_sizehi  equ $9400 | ((CCA_vram_size >> 9) & $ff)
+DMA_vram_addrlo  equ $9500 | ((CCA_vram_mirror >> 1) & $ff)
+DMA_vram_mirror  equ $96009700 | ((CCA_vram_mirror  << 7) & $ff0000) | ((CCA_vram_mirror  >> 17) & $7f)
+DMA_vram_mirror1 equ $96009700 | ((CCA_vram_mirror1 << 7) & $ff0000) | ((CCA_vram_mirror1 >> 17) & $7f)
+
 	;; Lesser globals
-scroll_pos:
-	ds	4
+scroll_vpos:
+	ds	2
+scroll_hpos:
+	ds	2
 mirror_ready:
 	ds	1
 reset_requested:			; Bit 0: reset request (START pressed)
@@ -112,7 +132,7 @@ HBL:
 VBL:	movem.l	d0-d2/a0-a1,-(sp)
 	bsr	ReadJoy1
 	movea.l #$00c00000,a0
-	lea	scroll_pos,a1
+	lea	scroll_vpos,a1
 	move.l	#$81648f02,4(a0) ; Word write, no DMA
 	;; VSRAM WRITE to $0000 (Vertical scroll table)
 	move.l	#$40000010,4(a0)
@@ -158,17 +178,17 @@ VBL:	movem.l	d0-d2/a0-a1,-(sp)
 .done:	movem.l	(sp)+,d0-d2/a0-a1
 	rte
 .dma:	move.l	#$40000083,d1		; Target DMA for first blit
-	move.l	#$9640977f,d2		; Source RAM for first blit
+	move.l	#DMA_vram_mirror,d2	; Source RAM for first blit
 	subq	#1,d0			; Is this the first blit?
 	bne.s	.first
 	move.l	#$60000083,d1		; If not, adjust target and source
-	move.l	#$9650977f,d2		; addresses as needed
+	move.l	#DMA_vram_mirror1,d2	; addresses as needed
 .first:	move.b	d0,mirror_ready		; Either way, save new blits-remaining
 	;; Now enable DMA, load in length and source addresses.
 	;; This assumes 512-byte alignment for each blit source, which we
 	;; do in fact have.
-	move.l	#$81749300,4(a0)
-	move.l	#$94109500,4(a0)
+	move.l	#($81740000 | DMA_vram_sizelo),4(a0)
+	move.l	#((DMA_vram_sizehi << 16) | DMA_vram_addrlo),4(a0)
 	move.l	d2,4(a0)
 	move.l	d1,4(a0)
 	bra	.done

--- a/genesis/cca.s
+++ b/genesis/cca.s
@@ -2,13 +2,10 @@
 	org	$ff0000
 
 ; automaton size in cells
-CCA_width  equ 128
+CCA_width  equ 128	; also size of a VRAM mirror row in bytes
 CCA_height equ 128
 
-; size of a row in bytes and in longwords
 CCA_row_bytes equ CCA_width / 2
-CCA_row_longs equ CCA_row_bytes / 4
-
 CCA_buf_size equ CCA_row_bytes * CCA_height
 CCA_buf_0:
 	ds	CCA_buf_size
@@ -16,14 +13,14 @@ CCA_buf_1:
 	ds	CCA_buf_size
 CCA_buf_xor equ CCA_buf_0 ^ CCA_buf_1
 
-CCA_vram_size equ CCA_width * CCA_height / 2
+CCA_plane_size equ CCA_width * CCA_height / 2
 CCA_vram_mirror:
-	ds	CCA_vram_size
+	ds	CCA_plane_size
 CCA_vram_mirror1:
-	ds	CCA_vram_size
+	ds	CCA_plane_size
 
-DMA_vram_sizelo  equ $9300 | ((CCA_vram_size >> 1) & $ff)
-DMA_vram_sizehi  equ $9400 | ((CCA_vram_size >> 9) & $ff)
+DMA_vram_sizelo  equ $9300 | ((CCA_plane_size >> 1) & $ff)
+DMA_vram_sizehi  equ $9400 | ((CCA_plane_size >> 9) & $ff)
 DMA_vram_addrlo  equ $9500 | ((CCA_vram_mirror >> 1) & $ff)
 DMA_vram_mirror  equ $96009700 | ((CCA_vram_mirror  << 7) & $ff0000) | ((CCA_vram_mirror  >> 17) & $7f)
 DMA_vram_mirror1 equ $96009700 | ((CCA_vram_mirror1 << 7) & $ff0000) | ((CCA_vram_mirror1 >> 17) & $7f)

--- a/genesis/ccamain.s
+++ b/genesis/ccamain.s
@@ -8,21 +8,17 @@ CCAInit:
 	;; Fall through to CCAReset
 
 CCAReset:
-	movem.l	d2-d3/a2,-(sp)
+	movem.l	d2/a2-a3,-(sp)
 	movea.l	CurBuf,a2
-	move.w	#(CCA_buf_size/4-1),d2
-.lp:	bsr	rnd
-	moveq	#3,d3
-.cell:	move.w	d0,d1
-	and.b	#$0f,d1
-	move.b	d1,(a2)+
-	lsr.w	#4,d0
-	dbra	d3,.cell
+	lea	rnd(pc),a3
+	move.w	#(CCA_buf_size/2-1),d2
+.lp:	jsr	(a3)
+	move.w	d0,(a2)+
 	dbra	d2,.lp
 	;; A reset has happened. Don't allow new reset requests until
 	;; START has been released for at least one frame.
 	move.b	#2,reset_requested
-	movem.l	(sp)+,d2-d3/a2
+	movem.l	(sp)+,d2/a2-a3
 	;; Fall through to CCARender
 
 CCARender:
@@ -32,22 +28,18 @@ CCARender:
 	movea.l	CurBuf,a0
 	lea	CCA_vram_mirror,a1
 	moveq	#(CCA_height/2-1),d0	; Pairs of rows
-.rows:	moveq	#(CCA_width/2-1),d1	; Pairs of columns
+.rows:	moveq	#(CCA_row_bytes-1),d1	; One two-cell byte becomes one nametable word
 .cols:	;; Bottom row first
-	move.w	#$0100,d2		; after the shift, v-flip on
-	move.b	CCA_width(a0),d2
-	asl.w	#4,d2
-	or.b	(CCA_width+1)(a0),d2
+	move.w	#$1000,d2		; v-flip on
+	move.b	CCA_row_bytes(a0),d2
 	move.w	d2,CCA_vram_size(a1)
 	;; Then top row, advancing our pointers
 	moveq	#$0,d2
 	move.b	(a0)+,d2
-	asl.w	#4,d2
-	or.b	(a0)+,d2
 	move.w	d2,(a1)+
 	dbra	d1,.cols
 	;; Skip the row we just dealt with
-	add.w	#CCA_width,a0
+	add.w	#CCA_row_bytes,a0
 	dbra	d0,.rows
 	;; Clean up, we're done
 	move.b	#2,mirror_ready
@@ -56,22 +48,91 @@ CCARender:
 
 	list macro
 
-	macro check_cell base, north, west, east, south
-	move.b	d4,d5
-	addq	#1,d5
-	and.b	#$0f,d5			; d5 = (d4 + 1) & 0x0f = target color
-	cmp.b	north(base),d5		; Check N neighbor
-	beq.s	.eat ## \?
-	cmp.b	west(base),d5		; Check W neighbor
-	beq.s	.eat ## \?
-	cmp.b	east(base),d5		; Check E neighbor
-	beq.s	.eat ## \?
-	cmp.b	south(base),d5		; Check S neighbor
-	bne.s	.next ## \?
-.eat ## \?
-	move.b	d5,d4			; Final color is one step up
-.next ## \?
+	;; SWARCMPNE PSEUDO-INSTRUCTION
+	;; For each lane, if any bits in that lane differ between srca and srcb,
+	;; the top bit of that lane in dest is set, otherwise it is cleared
+	;; The other bits in dest are garbage
+	;; mask delineates the lanes, i.e. $77777777 for a vector of nybbles
+	;; srca is preserved, srcb is clobbered
+	macro swarcmpne mask, srca, srcb, dest
+	eor.l	srca,srcb
+	move.l	srcb,dest
+	and.l	mask,dest
+	add.l	mask,dest
+	or.l	srcb,dest
 	endm
+
+	;; UPDATE EIGHT CELLS
+	;; west is offset to west neighbor after postincrement (-5, except at west edge)
+	;; east is offset to east neighbor after postincrement (0, except at east edge)
+	;; a1 points to source buffer
+	;; a2 points to destination buffer
+	;; a3 points to north neighbor row (a1 - CCA_row_bytes, except at north edge)
+	;; a4 points to south neighbor row (a1 + CCA_row_bytes, except at south edge)
+	;; a5 is reserved for an outer loop end condition
+	;; a6 must contain #$11111111 (vector of 1s added to cells to get target values)
+	;; d0 and d1 are scratch
+	;; d2 is reserved for an inner loop counter
+	;; d3 holds eight initial cell values
+	;; d4 holds eight target cell values
+	;; d5 accumulates a bitmask of cells that *don't* match any adjacent cells
+	;; d6 must contain #$77777777 (lane-delineating mask used in SWAR operations)
+	;; d7 must contain #$88888888 (lane-delineating mask used in SWAR operations)
+
+	macro updateeight west, east
+	;; get initial values and do SWAR addition to get target values
+	move.l	(a1)+,d3	; d3 = initial cell values
+	move.l	d3,d4
+	and.l	d6,d4		; (andi.l #$77777777,d4)
+	add.l	a6,d4		; (addi.l #$11111111,d4)
+	move.l	d3,d0
+	and.l	d7,d0		; (andi.l #$88888888,d0)
+	eor.l	d0,d4		; d4 = target cell values
+	;; compare with north neighbors
+	move.l	(a3)+,d0
+	swarcmpne d6, d4, d0, d5
+	;; compare with south neighbors
+	move.l	(a4)+,d0
+	swarcmpne d6, d4, d0, d1
+	and.l	d1,d5
+	;; compare with west neighbors
+	moveq	#$F0,d0		; sign extends to $FFFFFFF0
+	and.l	d3,d0		; abcdefgh -> abcdefg0
+	moveq	#$0F,d1
+	and.b	west(a1),d1	; 0L
+	or.l	d1,d0		; abcdefg0 -> abcdefgL
+	ror.l	#4,d0		; abcdefgL -> Labcdefg
+	swarcmpne d6, d4, d0, d1
+	and.l	d1,d5
+	;; compare with east neighbors
+	;; the east byte is the high byte of a longword, so the initial cells
+	;; and the new byte have to shift in opposite directions
+	move.l	d3,d0
+	lsl.l	#4,d0		; abcdefgh -> bcdefgh0
+	moveq	#0,d1
+	move.b	east(a1),d1	; R_
+	lsr.b	#4,d1		; 0R
+	or.l	d1,d0		; bcdefgh0 -> bcdefghR
+	swarcmpne d6, d4, d0, d1
+	and.l	d1,d5
+	;; make writeback mask (1111 = no match, keep d3; 0000 = match, keep d4)
+	;; mask out garbage bits, then multiply by 15 / 8 without overflowing
+	and.l	d7,d5		; (andi.l #$88888888,d5)
+	move.l	d5,d0
+	move.l	d5,d1		; d0 = d1 = d5 = 8 * mask
+	lsr.l	#3,d0		; d0 = 1 * mask
+	sub.l	d0,d5		; d5 -= 1 * mask
+	add.l	d1,d5		; d5 += 8 * mask
+	;; ((d3 ^ d4) & d5) ^ d4 = (d3 & d5) | (d4 & ~d5)
+	eor.l	d4,d3
+	and.l	d5,d3
+	eor.l	d4,d3
+	move.l	d3,(a2)+
+	endm
+
+lastrow  equ CCA_buf_size-CCA_row_bytes
+edgewest equ CCA_row_bytes-5
+edgeeast equ -CCA_row_bytes
 
 CCAStep:
 	;; Before anything else, check if we should reset instead
@@ -79,71 +140,45 @@ CCAStep:
 	btst	#0,d0
 	bne	CCAReset
 
-	movem.l	d2-d5/a2-a3,-(sp)
+	movem.l	d2-d7/a2-a6,-(sp)
+	movea.l	#$11111111,a6
+	move.l	#$77777777,d6
+	move.l	d6,d7
+	not.l	d7
 	movea.l	CurBuf,a0		; Source buffer
-	move.l	a0,d0			; Compute destination buffer by
-	eor.w	#CCA_buf_xor,d0		; flipping the $4000 bit
-	move.l	d0,a1			; Destination buffer
-	move.l	a1,CurBuf		; Which will be the next source buffer
+	movea.l a0,a1
+	move.l	a0,d0
+	eor.w	#CCA_buf_xor,d0		; Opposite buffer
+	movea.l	d0,a2			; ...is the destination buffer
+	move.l	d0,CurBuf		; ...and also the next source buffer
+	lea	lastrow(a0),a3		; north neighbor (wrap)
+	lea	CCA_row_bytes(a0),a4	; south neighbor
+	movea.l	a4,a5			; stop at the second row
+	bsr.s	updaterows
+	;; a1 now points to the second row
+	;; a3 now points to the end of the buffer
+	;; a4 now points to the third row
+	movea.l a0,a3			; reset north neighbor
+	lea	lastrow(a0),a5		; stop at the last row
+	bsr.s	updaterows
+	;; a1 now points to the last row
+	;; a3 now points to the second last row
+	;; a4 now points to the end of the buffer
+	movea.l	a4,a5			; stop at the end of the buffer
+	movea.l	a0,a4			; reset south neighbor (wrap)
+	bsr.s	updaterows
+	movem.l	(sp)+,d2-d7/a2-a6
+	rts
 
-	;; Check the internal points first
-	move.w	#(126*128-3),d2		; 126 non-edge rows and 128 columns,
-					; skipping the first and last
-	lea	129(a0),a2		; Point a2 to first non-edge cell
-	lea	129(a1),a3		; And do the same with a3 and target
-.lp:	move.b	(a2)+,d4		; d4 = this cell's color
-	move.b	d4,d5
-	addq	#1,d5
-	and.b	#$0f,d5			; d5 = (d4 + 1) & 0x0f = target color
-	cmp.b	-129(a2),d5		; Check N neighbor
-	beq.s	.eat
-	cmp.b	-2(a2),d5		; Check W neighbor
-	beq.s	.eat
-	cmp.b	(a2),d5			; Check E neighbor
-	beq.s	.eat
-	cmp.b	127(a2),d5		; Check S neighbor
-	bne.s	.skip
-.eat:	move.b	d5,(a3)+		; Store updated color in target
-	dbra	d2,.lp
-	bra.s	.cdone
-.skip:	move.b	d4,(a3)+		; Store initial color in target
-	dbra	d2,.lp
-.cdone:
-	;; Now check the corners
-	move.b	(a0),d4
-	check_cell a0, 1, 127, 128, $3f80
-	move.b	d4,(a1)
-	move.b	$7f(a0),d4
-	check_cell a0, 0, $7e, $ff, $3fff
-	move.b	d4,$7f(a1)
-	move.b	$3f80(a0),d4
-	check_cell a0, 0, $3f00, $3f81, $3fff
-	move.b	d4,$3f80(a1)
-	move.b	$3fff(a0),d4
-	check_cell a0, $7f, $3f7f, $3f80, $3ffe
-	move.b	d4,$3fff(a1)
-
-	;; Finally test the edges
-	lea	1(a0),a2		; Horizontal src pointer
-	lea	1(a1),a3		; Horizontal dest pointer
-	lea	128(a0),a0		; Vertical src pointer
-	lea	128(a1),a1		; Vertical dest pointer
-	moveq	#125,d2			; 126 cells
-.lp2:	move.b	$3f80(a2),d4
-	check_cell a2,0,$3f00,$3f7f,$3f81
-	move.b	d4,$3f80(a3)
-	move.b	(a2)+,d4
-	check_cell a2,-2,0,127,$3f7f
-	move.b	d4,(a3)+
-	move.b	(a0),d4
-	check_cell a0,-128,1,127,128
-	move.b	d4,(a1)
-	move.b	127(a0),d4
-	check_cell a0,-1,0,126,255
-	move.b	d4,127(a1)
-	lea	128(a0),a0
-	lea	128(a1),a1
-	dbra	d2,.lp2
-
-	movem.l	(sp)+,d2-d5/a2-a3
+	;; Does not preserve registers! Only to be called from CCAStep!
+	;; This routine is a whole lot bigger than it looks--so big that
+	;; the outer loop bne doesn't fit in a short branch
+updaterows:
+	updateeight edgewest, 0
+	moveq	#(CCA_row_longs-3),d2
+.cols	updateeight -5, 0
+	dbra	d2,.cols
+	updateeight -5, edgeeast
+	cmpa.l	a1,a5
+	bne	updaterows
 	rts

--- a/genesis/ccamain.s
+++ b/genesis/ccamain.s
@@ -100,7 +100,7 @@ CCARender:
 	and.l	d3,d0		; abcdefgh -> abcdefg0
 	moveq	#$0F,d1
 	and.b	west(a1),d1	; 0L
-	or.l	d1,d0		; abcdefg0 -> abcdefgL
+	or.b	d1,d0		; abcdefg0 -> abcdefgL
 	ror.l	#4,d0		; abcdefgL -> Labcdefg
 	swarcmpne d6, d4, d0, d1
 	and.l	d1,d5
@@ -109,10 +109,9 @@ CCARender:
 	;; and the new byte have to shift in opposite directions
 	move.l	d3,d0
 	lsl.l	#4,d0		; abcdefgh -> bcdefgh0
-	moveq	#0,d1
 	move.b	east(a1),d1	; R_
 	lsr.b	#4,d1		; 0R
-	or.l	d1,d0		; bcdefgh0 -> bcdefghR
+	or.b	d1,d0		; bcdefgh0 -> bcdefghR
 	swarcmpne d6, d4, d0, d1
 	and.l	d1,d5
 	;; make writeback mask (1111 = no match, keep d3; 0000 = match, keep d4)

--- a/genesis/ccamain.s
+++ b/genesis/ccamain.s
@@ -3,8 +3,19 @@ CurBuf: ds	4
 
 	seg	text
 CCAInit:
+	move.l	d2,-(sp)
 	move.l	#CCA_buf_0,CurBuf
 	move.w	#0,mirror_ready		; Also clears reset_requested
+	;; prepare VRAM mirror
+	lea	CCA_vram_mirror,a0
+	lea	CCA_plane_size(a0),a1
+	moveq	#0,d0
+	move.l	#$10001000,d1		; v-flip on
+	move.w	#(CCA_plane_size/4-1),d2
+.lp	move.l	d0,(a0)+
+	move.l	d1,(a1)+
+	dbra	d2,.lp
+	move.l	(sp)+,d2
 	;; Fall through to CCAReset
 
 CCAReset:
@@ -24,26 +35,51 @@ CCAReset:
 CCARender:
 	move.b	mirror_ready,d0
 	bne	CCARender
-	move.l	d2,-(sp)
+	movem.l	a2-a3,-(sp)
 	movea.l	CurBuf,a0
 	lea	CCA_vram_mirror,a1
-	moveq	#(CCA_height/2-1),d0	; Pairs of rows
-.rows:	moveq	#(CCA_row_bytes-1),d1	; One two-cell byte becomes one nametable word
-.cols:	;; Bottom row first
-	move.w	#$1000,d2		; v-flip on
-	move.b	CCA_row_bytes(a0),d2
-	move.w	d2,CCA_vram_size(a1)
-	;; Then top row, advancing our pointers
-	moveq	#$0,d2
-	move.b	(a0)+,d2
-	move.w	d2,(a1)+
-	dbra	d1,.cols
-	;; Skip the row we just dealt with
-	add.w	#CCA_row_bytes,a0
-	dbra	d0,.rows
+	movea.w	#CCA_plane_size,a2
+	movea.w	#(CCA_width-CCA_plane_size),a3
+	moveq	#(CCA_height-1),d0
+.lp	move.l	(a0)+,d1
+	movep.l	d1,1(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,9(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,17(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,25(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,33(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,41(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,49(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,57(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,65(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,73(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,81(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,89(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,97(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,105(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,113(a1)
+	move.l	(a0)+,d1
+	movep.l	d1,121(a1)
+	adda.l	a2,a1
+	exg	a2,a3
+	dbra	d0,.lp
 	;; Clean up, we're done
 	move.b	#2,mirror_ready
-	move.l	(sp)+,d2
+	movea.l	(sp)+,a2
+	movea.l	(sp)+,a3
 	rts
 
 	list macro
@@ -157,7 +193,7 @@ CCAStep:
 	;; a1 now points to the second row
 	;; a3 now points to the end of the buffer
 	;; a4 now points to the third row
-	movea.l a0,a3			; reset north neighbor
+	movea.l	a0,a3			; reset north neighbor
 	lea	lastrow(a0),a5		; stop at the last row
 	bsr.s	updaterows
 	;; a1 now points to the last row
@@ -174,7 +210,7 @@ CCAStep:
 	;; the outer loop bne doesn't fit in a short branch
 updaterows:
 	updateeight edgewest, 0
-	moveq	#(CCA_row_longs-3),d2
+	moveq	#(CCA_width/8-3),d2
 .cols	updateeight -5, 0
 	dbra	d2,.cols
 	updateeight -5, edgeeast

--- a/genesis/ccamain.s
+++ b/genesis/ccamain.s
@@ -10,7 +10,7 @@ CCAInit:
 CCAReset:
 	movem.l	d2-d3/a2,-(sp)
 	movea.l	CurBuf,a2
-	move.w	#4095,d2
+	move.w	#(CCA_buf_size/4-1),d2
 .lp:	bsr	rnd
 	moveq	#3,d3
 .cell:	move.w	d0,d1
@@ -31,14 +31,14 @@ CCARender:
 	move.l	d2,-(sp)
 	movea.l	CurBuf,a0
 	lea	CCA_vram_mirror,a1
-	moveq	#63,d0			; Pairs of rows
-.rows:	moveq	#63,d1			; Pairs of columns
+	moveq	#(CCA_height/2-1),d0	; Pairs of rows
+.rows:	moveq	#(CCA_width/2-1),d1	; Pairs of columns
 .cols:	;; Bottom row first
 	move.w	#$0100,d2		; after the shift, v-flip on
-	move.b	128(a0),d2
+	move.b	CCA_width(a0),d2
 	asl.w	#4,d2
-	or.b	129(a0),d2
-	move.w	d2,8192(a1)
+	or.b	(CCA_width+1)(a0),d2
+	move.w	d2,CCA_vram_size(a1)
 	;; Then top row, advancing our pointers
 	moveq	#$0,d2
 	move.b	(a0)+,d2
@@ -47,7 +47,7 @@ CCARender:
 	move.w	d2,(a1)+
 	dbra	d1,.cols
 	;; Skip the row we just dealt with
-	add.w	#128,a0
+	add.w	#CCA_width,a0
 	dbra	d0,.rows
 	;; Clean up, we're done
 	move.b	#2,mirror_ready
@@ -82,7 +82,7 @@ CCAStep:
 	movem.l	d2-d5/a2-a3,-(sp)
 	movea.l	CurBuf,a0		; Source buffer
 	move.l	a0,d0			; Compute destination buffer by
-	eor.w	#$4000,d0		; flipping the $4000 bit
+	eor.w	#CCA_buf_xor,d0		; flipping the $4000 bit
 	move.l	d0,a1			; Destination buffer
 	move.l	a1,CurBuf		; Which will be the next source buffer
 


### PR DESCRIPTION
Hi. I imagine you are surprised to receive a pull request in the repo that you use for the retrocoding projects on your blog. The thing is, I am a reader of your blog who has been rather successfully experimenting with one of your old projects, and opening a pull request was the best way I could think of to contact you and share my findings (I'm aware you have a Mastodon, but I'm not on that social network)

As I said, as a reader of your blog, I have been working my way backward through your older projects. The Sega Genesis CCA particularly caught my attention and inspired me to brush up on 68000 assembly language. After familiarizing myself with the language, I noticed a couple of inner loop microoptimizations that you had overlooked in your 2025 update to the project, and I thought of contacting you to inform you of those. But then I realized I might be thinking far too small.

I decided to try re-implementing the CCA algorithm from scratch using an approach that would be completely unreasonable on the 65816-powered SNES: vectorization. After all, the 68000 has eight lovely 32-bit data registers; it seems a waste to only use a byte of them. And addition-with-wrapping and comparison-for-equality are both relatively easy vector operations to implement in scalar instructions. On the other hand, many 32-bit arithmetic operations take twice as many cycles on the original 68000 as 16-bit operations do. I honestly wasn't sure whether vectorization would speed the automaton up significantly, if at all.

After writing the vectorized implementation (which uses every single register that isn't the stack pointer), plugging it in to your project, and testing it... I was pleasantly surprised. Please download and assemble my fork and see for yourself.

If you test this vectorized CCA on several different Genesis emulators and notice a large speed discrepancy between the emulators, I think I know the reason. There is a very old 68000 emulator called Musashi that some older Genesis emulators might be using. Musashi incorrectly uses the 68010 cycle counts for some instructions when emulating a 68000 (Musashi has a Github repo and there are open issues about this). The main category of affected instructions is 32-bit register-to-register arithmetic ops, which take 8 cycles on a 68000 but only 6 cycles on a 68010. The inner loop of the vectorized CCA consists almost entirely of 32-bit register-to-register arithmetic ops, so emulators based on Musashi will run it a lot faster than real hardware or emulators that use a more accurate 68000.